### PR TITLE
Respond with the correct error code and headers

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -22,7 +22,7 @@ if (config.get('bunyan') || config.get(env + ':use_bunyan')) {
   output = bunyan.createLogger(settings);
 } else {
   output = console;
-  console.debug = console.log.bind(console);
+  output.debug = console.log.bind(console);
 }
 
 module.exports = output;

--- a/lib/spserver.js
+++ b/lib/spserver.js
@@ -12,7 +12,7 @@ var logger = require('./logger');
 
 var env = config.get('NODE_ENV');
 
-var spserver = function(settings) {
+var spserver = function (settings) {
   if (!settings) {
     settings = config.get();
   }
@@ -28,7 +28,7 @@ var spserver = function(settings) {
     logger.debug('[REQ] GET:', req.url);
     var startTime = new Date().getTime();
 
-    var done = function() {
+    var done = function () {
       var requestTime = new Date().getTime() - startTime;
       logger.debug('[RES] GET:', req.url, '(' + res.statusCode + ') took', requestTime, 'ms');
     };
@@ -36,16 +36,18 @@ var spserver = function(settings) {
     res.addListener('finish', done);
     res.addListener('close', done);
 
-    //return base(req, res);
     req.addListener('end', function () {
-      fileServer.serve(req, res, function(e) {
-        if (!e) return;
-        if (e && e.status === 404 && base) {
-          return base(req, res);
+      fileServer.serve(req, res, function (err) {
+        if (err) {
+          if (err.status === 404 && base) {
+            return base(req, res);
+          } else {
+            logger.error(err);
+
+            res.writeHead(err.status, err.headers);
+            res.end();
+          }
         }
-        logger.error(e);
-        res.writeHead(404);
-        res.end();
       });
     }).resume();
   });


### PR DESCRIPTION
If we don't intercept the 404 request by running/loading the base page, we should error out with the specific error response.