### PR TITLE
Add config support for 'process.stderr'

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,13 +13,16 @@ var output;
 if (config.get('bunyan') || config.get(env + ':use_bunyan')) {
   var settings = _.cloneDeep(config.get(env + ':bunyan'));
 
-  for (var i = 0; i < settings.streams.length; i++) {
-    if (settings.streams[i].stream === 'process.stdout') {
-      settings.streams[i].stream = process.stdout;
-    } else if (settings.streams[i].stream === 'process.stderr') {
-      settings.streams[i].stream = process.stderr;
-    }
-  }
+  // Stream can be specified either in settings.streams[ix] or globally in settings.stream
+  _([settings.streams, settings])
+    .flatten()
+    .forEach(function (settingObj) {
+      if (settingObj.stream === 'process.stdout') {
+        settingObj.stream = process.stdout;
+      } else if (settingObj.stream === 'process.stderr') {
+        settingObj.stream = process.stderr;
+      }
+    });
 
   output = bunyan.createLogger(settings);
 } else {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -16,6 +16,8 @@ if (config.get('bunyan') || config.get(env + ':use_bunyan')) {
   for (var i = 0; i < settings.streams.length; i++) {
     if (settings.streams[i].stream === 'process.stdout') {
       settings.streams[i].stream = process.stdout;
+    } else if (settings.streams[i].stream === 'process.stderr') {
+      settings.streams[i].stream = process.stderr;
     }
   }
 


### PR DESCRIPTION
Allow logging output to stderr, in the same way we do logging to stdout; this allows unbuffered logging.